### PR TITLE
[FIX] FilterUtils의 filterWithPaging 메소드의 119라인에서의 필터링 조건 오류.

### DIFF
--- a/ax-boot-admin/src/main/java/com/chequer/axboot/admin/domain/code/CommonCode.java
+++ b/ax-boot-admin/src/main/java/com/chequer/axboot/admin/domain/code/CommonCode.java
@@ -3,6 +3,7 @@ package com.chequer.axboot.admin.domain.code;
 import com.chequer.axboot.admin.domain.BaseJpaModel;
 import com.chequer.axboot.core.annotations.ColumnPosition;
 import com.chequer.axboot.core.code.AXBootTypes;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.DynamicInsert;
@@ -20,6 +21,7 @@ import javax.validation.constraints.Size;
 @Entity
 @Table(name = "COMMON_CODE_M")
 @IdClass(CommonCodeId.class)
+@EqualsAndHashCode
 public class CommonCode extends BaseJpaModel<CommonCodeId> {
 
     @Id
@@ -94,5 +96,17 @@ public class CommonCode extends BaseJpaModel<CommonCodeId> {
         commonCode.setName(name);
         commonCode.setSort(sort);
         return commonCode;
+    }
+
+    @Override public boolean equals(Object obj) {
+
+        boolean result = false;
+
+        if (obj instanceof CommonCode) {
+            CommonCode commonCode = (CommonCode) obj;
+            return this.getId().equals(commonCode.getId()) ? true : false;
+        }
+
+        return result;
     }
 }


### PR DESCRIPTION
## 증상
화면에서 검색 조건으로 검색을 하였을때, 결과가 여러 건임에도 불구하고 한 건만 표시됨.

![axboot_1](https://cloud.githubusercontent.com/assets/24771131/21839553/a5948924-d81b-11e6-94fa-aa4cc9456bc4.png)
> STATUS로 검색 (화면에는 USER_STATUS가 2건.)

![axboot_2](https://cloud.githubusercontent.com/assets/24771131/21839587/dea739fa-d81b-11e6-91fc-fa14e6571614.png)

> 결과가 1건만 보임.

## 원인
- FilterUtils의 filterWithPaging 메소드 119라인에서 필터링하는 조건에 문제가 있어 보임.
```java
filterList.stream().filter(t -> !filteredList.contains(t)).forEach(filteredList::add);
```
- 검색조건에 일치하는지 리스트의 contains 메소드로 체크하는데 리스트의 contains는 원소의 equals가 같은지로 판단.

- CommonCode에 따로 equals 메소드를 오버라이드 구현해놓고 있지 않은 상태라서 리스트는 같은 원소로 판단하고 여러 건의 결과를 한건만 리스트에 저장.

![axboot_3](https://cloud.githubusercontent.com/assets/24771131/21839725/a79e4024-d81c-11e6-9289-f8196408607c.png)

## 해결
- 검색 조건에 해당하는 Bean들의 equals 함수를 재정의 함.