### PR TITLE
Replace DatatypeConverter with Commons Codec Base64

### DIFF
--- a/ax-boot-admin/src/main/java/com/chequer/axboot/admin/utils/JWTSessionHandler.java
+++ b/ax-boot-admin/src/main/java/com/chequer/axboot/admin/utils/JWTSessionHandler.java
@@ -3,11 +3,11 @@ package com.chequer.axboot.admin.utils;
 import com.chequer.axboot.admin.domain.user.SessionUser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.codec.binary.Base64;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
-import javax.xml.bind.DatatypeConverter;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.security.InvalidKeyException;
@@ -80,11 +80,11 @@ public final class JWTSessionHandler {
     }
 
     private String toBase64(byte[] content) {
-        return DatatypeConverter.printBase64Binary(content);
+        return Base64.encodeBase64URLSafeString(content);
     }
 
     private byte[] fromBase64(String content) {
-        return DatatypeConverter.parseBase64Binary(content);
+        return Base64.decodeBase64(content);
     }
 
     private synchronized byte[] createHmac(byte[] content) {


### PR DESCRIPTION
Replace "javax.xml.bind.DatatypeConverter" with "org.apache.commons.codec.binary.Base64", which is used for Base64 encoding / decoding.
"DatatypeConverter" caused a serious problem in "WildFly 9". The problem is that the session stored in the cookie can not be restored(or stored) properly.

아래 주소에 좀 더 자세한 설명을 남겼습니다.
[AXBoot: WildFly 9을 사용할 때의 JWTSessionHandler 문제](http://javaworld.co.kr/114)